### PR TITLE
[REG-1597] Use a custom editor to fix the property label

### DIFF
--- a/src/gg.regression.unity.testing/Assets/Scripts/Editor/AutomationControllerEditor.cs
+++ b/src/gg.regression.unity.testing/Assets/Scripts/Editor/AutomationControllerEditor.cs
@@ -1,0 +1,20 @@
+using RegressionGames.Unity.Automation;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace RegressionGames.Unity
+{
+    [CustomEditor(typeof(AutomationController))]
+    public class AutomationControllerEditor: Editor
+    {
+        public override VisualElement CreateInspectorGUI()
+        {
+            var myInspector = new VisualElement();
+
+            myInspector.Add(new PropertyField(serializedObject.FindProperty("dontDestroyOnLoad"),"Don't Destroy on Load"));
+
+            return myInspector;
+        }
+    }
+}

--- a/src/gg.regression.unity.testing/Assets/Scripts/Editor/AutomationControllerEditor.cs.meta
+++ b/src/gg.regression.unity.testing/Assets/Scripts/Editor/AutomationControllerEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 498f589c3a5c4a06ab98a22f3d79c129
+timeCreated: 1706131295

--- a/src/gg.regression.unity.testing/Assets/Scripts/Runtime/Automation/AutomationController.cs
+++ b/src/gg.regression.unity.testing/Assets/Scripts/Runtime/Automation/AutomationController.cs
@@ -16,7 +16,6 @@ namespace RegressionGames.Unity.Automation
         // For now though, we'll implement those finders by iterating the list, until we have a need to optimize.
         private readonly List<AutomationEntity> m_Entities = new();
 
-        [HideInInspector]
         public AutomationRecorder automationRecorder;
 
         [Tooltip("If true, the controller will automatically set 'DontDestroyOnLoad' on itself when spawned.")]


### PR DESCRIPTION
Pretty simple.

Before:

<img width="724" alt="image" src="https://github.com/Regression-Games/RegressionGames.Unity.Testing/assets/7574/b0766e71-140b-41b1-b654-4543e8bd4454">

After:

<img width="722" alt="image" src="https://github.com/Regression-Games/RegressionGames.Unity.Testing/assets/7574/2024246c-679b-4896-81b0-c1f435351f68">

The problem is Unity doesn't provide a built-in way to set the _label_ for a property, for some reason. So instead you have to create a completely custom editor 🙄 

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
