### PR TITLE
[REG-1612] Set an iteration limit on the GPT Assistant Bot

### DIFF
--- a/src/gg.regression.unity.testing/Assets/Scripts/Runtime/Automation/GptAssistantBot.cs
+++ b/src/gg.regression.unity.testing/Assets/Scripts/Runtime/Automation/GptAssistantBot.cs
@@ -63,6 +63,9 @@ Be patient, but raise an exception if the game has not progressed after 5 or mor
         public OpenAICredentials openAiCredentials;
         public string openAiModel = "gpt-4-1106-preview";
 
+        [Tooltip("The maximum number of steps the bot is allowed to take before giving up. Set this to '0' to disable the iteration limit (NOT RECOMMENDED).")]
+        public int maximumIterations = 20;
+
         [TextArea(3, 10)]
         public string goal;
 
@@ -72,6 +75,7 @@ Be patient, but raise an exception if the game has not progressed after 5 or mor
         private bool m_Thinking;
         private OpenAIClient m_OpenAIClient;
         private readonly ChatCompletionsOptions m_Conversation = new();
+        private int m_IterationCount;
 
         public GptAssistantBot()
         {
@@ -109,7 +113,16 @@ Be patient, but raise an exception if the game has not progressed after 5 or mor
                 return;
             }
 
+            if(maximumIterations != 0 && m_IterationCount >= maximumIterations)
+            {
+                m_Log.Error($"Maximum iteration count of {maximumIterations} reached. Stopping bot.");
+                StopBot();
+                return;
+            }
+
             m_Thinking = true;
+
+            m_IterationCount++;
 
             try
             {


### PR DESCRIPTION
I am paranoid. I don't want the GPT Assistant Bot to end up in an infinite loop, trying different things until it entirely exhausts the user's spending limit 🤣 . For now, the easiest way to avoid that is a hard iteration count. Basically, this limits the number of times the bot can activate to `20`, by default. This limit is configurable and can be removed by the user (by setting the limit to `0`). We can add other more heuristic means of detecting a lack of progress later, but for now we have a relatively safe way of capping the number of requests a bot can make.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
